### PR TITLE
Fix broken links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,11 +77,11 @@ The framework is written as an extension to `OpenAI's Gym framework <https://git
 
 Contents
 ----------------
-- `Installation <https://marlo.readthedocs.io/en/latest/installation/>`_
-- `Usage <https://marlo.readthedocs.io/en/latest/usage/>`_
-- `Available Environments <https://marlo.readthedocs.io/en/latest/available_envs/>`_
-- `Submission Instructions <https://marlo.readthedocs.io/en/latest/submit/>`_
-- `Development <https://marlo.readthedocs.io/en/latest/development/>`_
+- `Installation <https://marlo.readthedocs.io/en/latest/installation.html>`_
+- `Usage <https://marlo.readthedocs.io/en/latest/usage.html>`_
+- `Available Environments <https://marlo.readthedocs.io/en/latest/available_envs.html>`_
+- `Submission Instructions <https://marlo.readthedocs.io/en/latest/submit.html>`_
+- `Development <https://marlo.readthedocs.io/en/latest/development.html>`_
 
 Simple Example
 ----------------


### PR DESCRIPTION
The links in the .rst file did not match those of the actual website.