### PR TITLE
Stability improvements

### DIFF
--- a/marlo/base_env_builder.py
+++ b/marlo/base_env_builder.py
@@ -619,19 +619,19 @@ class MarloEnvBuilderBase(gym.Env):
         if (self.params.kill_clients_after_num_rounds and
                 self._rounds > self.params.kill_clients_after_num_rounds):
             if self.params.role == 0:
-                print("Kill clients " + self.params.experiment_id)
+                print("Restart Malmo clients " + self.params.experiment_id)
                 for client in self.client_pool.clients:
                     for _ in range(3):
                         try:
-                            print("Kill " + str(client))
+                            print("Stopping " + str(client))
                             self.agent_host.killClient(client)
                             break
                         except MalmoPython.MissionException:
                             time.sleep(2)
 
-            print("Pause for restarts")
-            time.sleep(60 * len(self.client_pool.clients))
-            self._rounds = 0
+            print("Pause for restarts ....")
+            time.sleep(90 + 30 * len(self.client_pool.clients))
+            self._rounds = 1
 
         # If a mission is already running, try to quit it
         # Note : This assumes that <MissionQuitCommands/> is an allowed

--- a/marlo/base_env_builder.py
+++ b/marlo/base_env_builder.py
@@ -690,8 +690,7 @@ class MarloEnvBuilderBase(gym.Env):
                     time.sleep(0.1)
                     world_state = self.agent_host.getWorldState()
                     for error in world_state.errors:
-                        logger.error("Error", error)
-                        logger.warn(error.text)
+                        logger.error("Mission start error: " + error.text)
                     if any(world_state.errors):
                         raise MalmoPython.MissionException("Error while waiting for mission to start",
                                                            world_state.errors[0])


### PR DESCRIPTION
Minecraft can become unstable over time and missions can fail to start correctly. Optional settings to use the "killClient" AgentHost API call to restart minecraft as well as better testing for error states.