### PR TITLE
Added explicit import for gym.spaces

### DIFF
--- a/marlo/base_env_builder.py
+++ b/marlo/base_env_builder.py
@@ -2,6 +2,7 @@
 import time
 import json
 import gym
+import gym.spaces
 import numpy as np
 import marlo
 from marlo import MalmoPython


### PR DESCRIPTION
See https://github.com/openai/gym/issues/376

Unless you import it explicitly (either directly or by eg. calling gym.make), gym.spaces will not be added to the local scope of gym. Below an error log that can be reproduced by running the single_agent.py example with no prior calls to any libraries (macOS Mojave, gym 0.10.8, Python 3.6.6, conda 4.5.11):

```Traceback (most recent call last):
  File "server.py", line 11, in <module>
    "client_pool": client_pool
  File "/anaconda3/envs/malmo_n/lib/python3.6/site-packages/marlo/__init__.py", line 96, in make
    join_tokens = env.init(params, dry_run=True)
  File "/anaconda3/envs/malmo_n/lib/python3.6/site-packages/marlo/base_env_builder.py", line 598, in init
    self.build_env(self.params)
  File "/anaconda3/envs/malmo_n/lib/python3.6/site-packages/marlo/base_env_builder.py", line 622, in build_env
    self.setup_observation_space(params)
  File "/anaconda3/envs/malmo_n/lib/python3.6/site-packages/marlo/base_env_builder.py", line 370, in setup_observation_space
    self.observation_space = gym.spaces.Box(
AttributeError: module 'gym' has no attribute 'spaces'```