### PR TITLE
Fix continuous command formatting

### DIFF
--- a/marlo/base_env_builder.py
+++ b/marlo/base_env_builder.py
@@ -795,12 +795,12 @@ class MarloEnvBuilderBase(gym.Env):
                 self.send_command(_commands[_actions])
             elif isinstance(_spaces, gym.spaces.Box):
                 for command, value in zip(_commands, _actions):
-                    _command = "{}-{}".format(command, value)
+                    _command = "{} {}".format(command, value)
                     logger.debug(_command)
                     self.send_command(_command)
             elif isinstance(_spaces, gym.spaces.MultiDiscrete):
                 for command, value in zip(_commands, _actions):
-                    _command = "{}-{}".format(command, value)
+                    _command = "{} {}".format(command, value)
                     logger.debug(_command)
                     self.send_command(_command)
             else:


### PR DESCRIPTION
Fix for small error in the continuous action handling where it, for example, attempted to send "move-0.5" instead of the correct "move 0.5".